### PR TITLE
Handle nulls in the Siren response

### DIFF
--- a/ksiren-gson-adapter/build.gradle
+++ b/ksiren-gson-adapter/build.gradle
@@ -2,7 +2,7 @@ def group = "com.brightspace.ksiren"
 def artifactName = "ksiren-gson-adapter"
 def vcsUrlSetting = "https://github.com/Brightspace/ksiren/"
 def description = 'Adapter to enable KSiren to parse Siren entities from JSON using Gson.'
-def versionValue = "1.1.0-beta2"
+def versionValue = "1.1.0-beta3"
 
 dependencies {
 	compile 'org.jetbrains.kotlin:kotlin-stdlib:1.1.51'

--- a/ksiren-gson-adapter/src/main/java/com/brightspace/ksiren/gson_adapter/KSirenGsonAdapter.kt
+++ b/ksiren-gson-adapter/src/main/java/com/brightspace/ksiren/gson_adapter/KSirenGsonAdapter.kt
@@ -19,7 +19,7 @@ import com.google.gson.stream.JsonReader
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-class KSirenGsonAdapter(val gsonReader: JsonReader) : KSirenJsonReader {
+class KSirenGsonAdapter(val gsonReader: JsonReader) : KSirenJsonReader() {
 	override fun beginObject() {
 		gsonReader.beginObject()
 	}
@@ -44,15 +44,16 @@ class KSirenGsonAdapter(val gsonReader: JsonReader) : KSirenJsonReader {
 		return gsonReader.nextName()
 	}
 
-	override fun nextString(): String {
-		try {
-			return gsonReader.nextString()
-		} catch( e: Exception) {
-			throw KSirenException.ParseException(e.message?:"Reading string failed")
-		}
+	override fun nextStringImpl(): String {
+		return gsonReader.nextString()
 	}
 
 	override fun nextBoolean(): String {
 		return gsonReader.nextBoolean().toString()
+	}
+
+	override fun nextNull(): String {
+		gsonReader.nextNull()
+		return ""
 	}
 }

--- a/ksiren-gson-adapter/src/main/java/com/brightspace/ksiren/gson_adapter/KSirenGsonAdapter.kt
+++ b/ksiren-gson-adapter/src/main/java/com/brightspace/ksiren/gson_adapter/KSirenGsonAdapter.kt
@@ -52,8 +52,7 @@ class KSirenGsonAdapter(val gsonReader: JsonReader) : KSirenJsonReader() {
 		return gsonReader.nextBoolean().toString()
 	}
 
-	override fun nextNull(): String {
+	override fun nextNull() {
 		gsonReader.nextNull()
-		return ""
 	}
 }

--- a/ksiren-moshi-adapter/build.gradle
+++ b/ksiren-moshi-adapter/build.gradle
@@ -5,7 +5,7 @@ def description = 'Adapter to enable KSiren to parse Siren entities from JSON us
 def versionValue = "1.1.0-beta3"
 
 dependencies {
-	compile 'org.jetbrains.kotlin:kotlin-stdlib:1.1.3-2'
+	compile 'org.jetbrains.kotlin:kotlin-stdlib:1.1.51'
 	compile 'com.squareup.moshi:moshi:1.5.0'
 	implementation 'javax.annotation:jsr250-api:1.0'
 

--- a/ksiren-moshi-adapter/build.gradle
+++ b/ksiren-moshi-adapter/build.gradle
@@ -2,7 +2,7 @@ def group = "com.brightspace.ksiren"
 def artifactName = "ksiren-moshi-adapter"
 def vcsUrlSetting = "https://github.com/Brightspace/ksiren/"
 def description = 'Adapter to enable KSiren to parse Siren entities from JSON using Moshi.'
-def versionValue = "1.1.0-beta2"
+def versionValue = "1.1.0-beta3"
 
 dependencies {
 	compile 'org.jetbrains.kotlin:kotlin-stdlib:1.1.3-2'

--- a/ksiren-moshi-adapter/src/main/java/com/brightspace/ksiren/moshi_adapter/KSirenMoshiAdapter.kt
+++ b/ksiren-moshi-adapter/src/main/java/com/brightspace/ksiren/moshi_adapter/KSirenMoshiAdapter.kt
@@ -56,8 +56,7 @@ class KSirenMoshiAdapter(val moshiReader: JsonReader) : KSirenJsonReader() {
 		return moshiReader.nextBoolean().toString()
 	}
 
-	override fun nextNull(): String {
+	override fun nextNull() {
 		moshiReader.nextNull<String>()
-		return ""
 	}
 }

--- a/ksiren-moshi-adapter/src/main/java/com/brightspace/ksiren/moshi_adapter/KSirenMoshiAdapter.kt
+++ b/ksiren-moshi-adapter/src/main/java/com/brightspace/ksiren/moshi_adapter/KSirenMoshiAdapter.kt
@@ -19,7 +19,7 @@ import com.squareup.moshi.JsonReader
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-class KSirenMoshiAdapter(val moshiReader: JsonReader) : KSirenJsonReader {
+class KSirenMoshiAdapter(val moshiReader: JsonReader) : KSirenJsonReader() {
 	override fun beginObject() {
 		moshiReader.beginObject()
 	}
@@ -44,7 +44,7 @@ class KSirenMoshiAdapter(val moshiReader: JsonReader) : KSirenJsonReader {
 		return moshiReader.nextName()
 	}
 
-	override fun nextString(): String {
+	override fun nextStringImpl(): String {
 		try {
 			return moshiReader.nextString()
 		} catch( e: Exception) {
@@ -54,5 +54,10 @@ class KSirenMoshiAdapter(val moshiReader: JsonReader) : KSirenJsonReader {
 
 	override fun nextBoolean(): String {
 		return moshiReader.nextBoolean().toString()
+	}
+
+	override fun nextNull(): String {
+		moshiReader.nextNull<String>()
+		return ""
 	}
 }

--- a/ksiren-okhttp3-plugin/build.gradle
+++ b/ksiren-okhttp3-plugin/build.gradle
@@ -2,7 +2,7 @@ def group = "com.brightspace.ksiren"
 def artifactName = "ksiren-okhttp3-plugin"
 def vcsUrlSetting = "https://github.com/Brightspace/ksiren/"
 def description = 'Adapter to enable KSiren to create Okhttp3 Requests out of Siren actions and fetch entities using an Okhttp3 client.'
-def versionValue = "1.1.0-beta2"
+def versionValue = "1.1.0-beta3"
 
 dependencies {
 	compile 'org.jetbrains.kotlin:kotlin-stdlib:1.1.51'

--- a/ksiren/build.gradle
+++ b/ksiren/build.gradle
@@ -5,7 +5,7 @@ def group = "com.brightspace.ksiren"
 def artifactName = "ksiren"
 def vcsUrlSetting = "https://github.com/Brightspace/ksiren/"
 def description = 'Main package of KSiren: A Kotlin library for parsing responses from Siren API endpoints and building Siren Action requests.'
-def versionValue = "1.1.0-beta2"
+def versionValue = "1.1.0-beta3"
 
 dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib:1.1.51'

--- a/ksiren/src/main/java/com/brightspace/ksiren/Action.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Action.kt
@@ -27,10 +27,10 @@ class Action(
 	companion object {
 
 		fun fromJson(reader: KSirenJsonReader): Action {
-			var name: String = ""
+			var name = ""
 			val classes: MutableList<String> = mutableListOf()
-			var method: String = "GET"
-			var href: String = ""
+			var method = "GET"
+			var href = ""
 			var title: String? = null
 			var type = ContentType.FORM
 			val fields: MutableList<Field> = mutableListOf()
@@ -41,24 +41,24 @@ class Action(
 					"class" -> {
 						reader.beginArray()
 						while (reader.hasNext()) {
-							classes.add(reader.nextString())
+							conditionalRead(reader, {classes.add(it)})
 						}
 						reader.endArray()
 					}
 					"name" -> {
-						name = reader.nextString()
+						conditionalRead(reader, {name = it})
 					}
 					"method" -> {
-						method = reader.nextString()
+						conditionalRead(reader, {method = it})
 					}
 					"href" -> {
-						href = reader.nextString()
+						conditionalRead(reader, {href = it})
 					}
 					"title" -> {
 						title = reader.nextString()
 					}
 					"type" -> {
-						type = ContentType.parse(reader.nextString())
+						conditionalRead(reader, {type = ContentType.parse(it)})
 					}
 					"fields" -> {
 						reader.beginArray()

--- a/ksiren/src/main/java/com/brightspace/ksiren/ConditionalRead.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/ConditionalRead.kt
@@ -1,0 +1,11 @@
+package com.brightspace.ksiren
+
+/**
+ * Created by mpomeroy on 11/8/17.
+ */
+fun conditionalRead(reader: KSirenJsonReader, setter:(String) -> Unit) {
+	val string = reader.nextString()
+	if (string != null) {
+		setter.invoke(string)
+	}
+}

--- a/ksiren/src/main/java/com/brightspace/ksiren/Entity.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Entity.kt
@@ -44,14 +44,18 @@ class Entity(
 					"class" -> {
 						reader.beginArray()
 						while (reader.hasNext()) {
-							classes.add(reader.nextString())
+							conditionalRead(reader, {classes.add(it)})
 						}
 						reader.endArray()
 					}
 					"properties" -> {
 						reader.beginObject()
 						while (reader.hasNext()) {
-							properties.put(reader.nextName(), reader.nextString())
+							val propName = reader.nextName()
+							val value = reader.nextString()
+							if (value != null) {
+								properties.put(propName, value)
+							}
 						}
 						reader.endObject()
 					}
@@ -86,7 +90,7 @@ class Entity(
 					"rel" -> {
 						reader.beginArray()
 						while (reader.hasNext()) {
-							rel.add(reader.nextString())
+							conditionalRead(reader, {rel.add(it)})
 						}
 						reader.endArray()
 					}

--- a/ksiren/src/main/java/com/brightspace/ksiren/Field.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Field.kt
@@ -24,26 +24,26 @@ class Field(
 	companion object {
 
 		fun fromJson(reader: KSirenJsonReader): Field {
-			var name: String = ""
+			var name = ""
 			val classes: MutableList<String> = mutableListOf()
-			var type: String = "text"
+			var type = "text"
 			var value: String? = null
 
 			reader.beginObject()
 			while (reader.hasNext()) {
 				when (reader.nextName()) {
 					"name" -> {
-						name = reader.nextString()
+						conditionalRead(reader, {name = it})
 					}
 					"class" -> {
 						reader.beginArray()
 						while (reader.hasNext()) {
-							classes.add(reader.nextString())
+							conditionalRead(reader, {classes.add(it)})
 						}
 						reader.endArray()
 					}
 					"type" -> {
-						type = reader.nextString()
+						conditionalRead(reader, {type = it})
 					}
 					"value" -> {
 						value = reader.nextString()
@@ -51,7 +51,7 @@ class Field(
 				}
 			}
 			reader.endObject()
-			val finishedField: Field = Field(name, classes, type, value)
+			val finishedField = Field(name, classes, type, value)
 			return validate(finishedField)
 		}
 

--- a/ksiren/src/main/java/com/brightspace/ksiren/Field.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Field.kt
@@ -46,11 +46,7 @@ class Field(
 						type = reader.nextString()
 					}
 					"value" -> {
-						try {
-							value = reader.nextString()
-						} catch(e:KSirenException.ParseException) {
-							value = reader.nextBoolean()
-						}
+						value = reader.nextString()
 					}
 				}
 			}

--- a/ksiren/src/main/java/com/brightspace/ksiren/KSirenJsonReader.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/KSirenJsonReader.kt
@@ -15,17 +15,39 @@ package com.brightspace.ksiren
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-interface KSirenJsonReader {
+abstract class KSirenJsonReader {
 
-	fun beginObject()
-	fun endObject()
+	abstract fun beginObject()
+	abstract fun endObject()
 
-	fun beginArray()
-	fun endArray()
+	abstract fun beginArray()
+	abstract fun endArray()
 
-	fun hasNext(): Boolean
-	fun nextName(): String
-	fun nextString(): String
-	fun nextBoolean(): String
+	abstract fun hasNext(): Boolean
+	abstract fun nextName(): String
+
+	fun nextString(): String {
+		try {
+			return nextStringImpl()
+		} catch (e: Exception) {
+			//Do nothing, try reading booleans and nulls first
+		}
+
+		try {
+			return nextBoolean()
+		} catch (e: Exception) {
+			//Do nothing, try reading nulls first
+		}
+
+		try {
+			return nextNull()
+		} catch(e: Exception) {
+			throw KSirenException.ParseException(e.message?:"Could not parse value as String, Boolean or null value.")
+		}
+	}
+
+	abstract fun nextStringImpl(): String
+	abstract protected fun nextBoolean(): String
+	abstract protected fun nextNull(): String
 
 }

--- a/ksiren/src/main/java/com/brightspace/ksiren/KSirenJsonReader.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/KSirenJsonReader.kt
@@ -26,7 +26,7 @@ abstract class KSirenJsonReader {
 	abstract fun hasNext(): Boolean
 	abstract fun nextName(): String
 
-	fun nextString(): String {
+	fun nextString(): String? {
 		try {
 			return nextStringImpl()
 		} catch (e: Exception) {
@@ -40,7 +40,8 @@ abstract class KSirenJsonReader {
 		}
 
 		try {
-			return nextNull()
+			nextNull()
+			return null
 		} catch(e: Exception) {
 			throw KSirenException.ParseException(e.message?:"Could not parse value as String, Boolean or null value.")
 		}
@@ -48,6 +49,6 @@ abstract class KSirenJsonReader {
 
 	abstract fun nextStringImpl(): String
 	abstract protected fun nextBoolean(): String
-	abstract protected fun nextNull(): String
+	abstract protected fun nextNull()
 
 }

--- a/ksiren/src/main/java/com/brightspace/ksiren/Link.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Link.kt
@@ -81,6 +81,10 @@ class Link(
 		return rels.containsAll(rel.toList())
 	}
 
+	fun hasClass(vararg clazz: String): Boolean {
+		return classes.containsAll(clazz.toList())
+	}
+
 	override fun toJson(): CharSequence {
 		return JsonUtils.toJson(this)
 	}

--- a/ksiren/src/main/java/com/brightspace/ksiren/Link.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Link.kt
@@ -27,7 +27,7 @@ class Link(
 		fun fromJson(reader: KSirenJsonReader): Link {
 			val rels: MutableList<String> = mutableListOf()
 			val classes: MutableList<String> = mutableListOf()
-			var href: String = ""
+			var href = ""
 			var title: String? = null
 			var type: String? = null
 
@@ -37,19 +37,19 @@ class Link(
 					"rel" -> {
 						reader.beginArray()
 						while (reader.hasNext()) {
-							rels.add(reader.nextString())
+							conditionalRead(reader, {rels.add(it)})
 						}
 						reader.endArray()
 					}
 					"class" -> {
 						reader.beginArray()
 						while (reader.hasNext()) {
-							classes.add(reader.nextString())
+							conditionalRead(reader, {classes.add(it)})
 						}
 						reader.endArray()
 					}
 					"href" -> {
-						href = reader.nextString()
+						conditionalRead(reader, {href = it})
 					}
 					"title" -> {
 						title = reader.nextString()

--- a/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
@@ -31,6 +31,17 @@ class EntityTest {
         assertEquals(listOf("order"), entity.classes)
     }
 
+	@Test
+	fun expectHandledNulls() {
+		val json = """{ "class": [ "order" ], "properties": { "orderNumber": null, "itemCount": "3", "status": null }, "links": [{ "rel": [ "self" ], "href": "http://api.x.io/customers/pj123" }] }"""
+
+		val entity: Entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertTrue(entity.actions.isEmpty())
+		assertTrue(entity.links.isNotEmpty())
+		assertTrue(entity.properties.size == 3)
+		assertEquals(listOf("order"), entity.classes)
+	}
+
     @Test
     fun serializeToJson() {
         // the parser cannot handle linked entities

--- a/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
@@ -38,7 +38,7 @@ class EntityTest {
 		val entity: Entity = Entity.fromJson(json.toKSirenJsonReader())
 		assertTrue(entity.actions.isEmpty())
 		assertTrue(entity.links.isNotEmpty())
-		assertTrue(entity.properties.size == 3)
+		assertTrue(entity.properties.size == 1)
 		assertEquals(listOf("order"), entity.classes)
 	}
 

--- a/ksiren/src/test/java/com/brightspace/ksiren/FieldTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/FieldTest.kt
@@ -3,6 +3,7 @@ package com.brightspace.ksiren
 import com.squareup.moshi.JsonEncodingException
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Copyright 2017 D2L Corporation
@@ -22,10 +23,12 @@ import kotlin.test.assertEquals
 class FieldTest {
     @Test
     fun expectField() {
-        val field: Field = Field.fromJson("""{ "name": "orderNumber", "type": "hidden", "value": "42" }""".toKSirenJsonReader())
+        val field: Field = Field.fromJson("""{ "class":["class1", "class2"], "name": "orderNumber", "type": "hidden", "value": "42" }""".toKSirenJsonReader())
         assertEquals("orderNumber", field.name)
         assertEquals("hidden", field.type)
         assertEquals("42", field.value)
+        assertTrue(field.classes.contains("class1"))
+        assertTrue(field.classes.contains("class2"))
     }
 
 	@Test

--- a/ksiren/src/test/java/com/brightspace/ksiren/FieldTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/FieldTest.kt
@@ -36,6 +36,14 @@ class FieldTest {
 		assertEquals("false", field.value)
 	}
 
+	@Test
+	fun nullParseTest() {
+		val field: Field = Field.fromJson("""{ "name": "expressShipping", "type": "checkbox", "value": null }""".toKSirenJsonReader())
+		assertEquals("expressShipping", field.name)
+		assertEquals("checkbox", field.type)
+		assertEquals("", field.value)
+	}
+
     @Test
     fun expectJsonException() {
         try {

--- a/ksiren/src/test/java/com/brightspace/ksiren/FieldTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/FieldTest.kt
@@ -44,7 +44,7 @@ class FieldTest {
 		val field: Field = Field.fromJson("""{ "name": "expressShipping", "type": "checkbox", "value": null }""".toKSirenJsonReader())
 		assertEquals("expressShipping", field.name)
 		assertEquals("checkbox", field.type)
-		assertEquals("", field.value)
+		assertEquals(null, field.value)
 	}
 
     @Test

--- a/ksiren/src/test/java/com/brightspace/ksiren/LinkTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/LinkTest.kt
@@ -2,6 +2,8 @@ package com.brightspace.ksiren
 
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Copyright 2017 D2L Corporation
@@ -26,6 +28,8 @@ class LinkTest {
 
         assertEquals(listOf("self"), link.rels)
         assertEquals("http://api.x.io/orders/42", link.href)
+		assertTrue(link.hasClass("link"))
+		assertFalse(link.hasClass("notLink"))
     }
 
     @Test


### PR DESCRIPTION
Added handling of null values in Siren responses, moved the responsibility of type mapping from boolean and null to String to the JsonReader definition.