### PR TITLE
Handle (ignore) object and array property values

### DIFF
--- a/ksiren/build.gradle
+++ b/ksiren/build.gradle
@@ -5,7 +5,7 @@ def group = "com.brightspace.ksiren"
 def artifactName = "ksiren"
 def vcsUrlSetting = "https://github.com/Brightspace/ksiren/"
 def description = 'Main package of KSiren: A Kotlin library for parsing responses from Siren API endpoints and building Siren Action requests.'
-def versionValue = "1.1.0"
+def versionValue = "1.1.1"
 
 dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib:1.3.31'

--- a/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
@@ -42,6 +42,43 @@ class EntityTest {
 		assertEquals(listOf("order"), entity.classes)
 	}
 
+	@Test
+	fun expectIgnoreArrayProperties() = expectIgnoreProperty("""["a", "b", "c"]""")
+
+	@Test
+	fun expectIgnoreObjectProperties() = expectIgnoreProperty("""{"foo": "bar", "fizz": "buzz"}""")
+
+	@Test
+	fun expectIgnoreArrayInArrayProperty() = expectIgnoreProperty("""["a", ["foo", "bar"], "c"]""")
+
+	@Test
+	fun expectIgnoreObjectInArrayProperty() = expectIgnoreProperty("""["a", {"foo": "bar"}, "c"]""")
+
+	@Test
+	fun expectIgnoreArrayInObjectProperty() = expectIgnoreProperty("""{"foo": "bar", "baz": ["bing", "fling"], "fizz": "buzz"}""")
+
+	@Test
+	fun expectIgnoreObjectInObjectProperty() = expectIgnoreProperty("""{"foo": "bar", "baz": {"bing": "fling"}, "fizz": "buzz"}""")
+
+	fun expectIgnoreProperty(ignoredPropertyJson: String) {
+		val json = """{ "class": [ "order" ], "properties": { "orderNumber": "42", "ignoredProperty": """ + ignoredPropertyJson + """, "status": "pending" }, "links": [{ "rel": [ "self" ], "href": "http://api.x.io/customers/pj123" }] }"""
+		val entity: Entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(mapOf("orderNumber" to "42", "status" to "pending"), entity.properties)
+		assertEquals(listOf("order"), entity.classes)
+		assertTrue(entity.actions.isEmpty())
+		assertTrue(entity.links.isNotEmpty())
+	}
+
+	@Test
+	fun expectHandleNumber() {
+		val json = """{ "class": [ "order" ], "properties": { "orderNumber": 42, "status": "pending" }, "links": [{ "rel": [ "self" ], "href": "http://api.x.io/customers/pj123" }] }"""
+		val entity: Entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(mapOf("orderNumber" to "42", "status" to "pending"), entity.properties)
+		assertEquals(listOf("order"), entity.classes)
+		assertTrue(entity.actions.isEmpty())
+		assertTrue(entity.links.isNotEmpty())
+	}
+
     @Test
     fun serializeToJson() {
         // the parser cannot handle linked entities


### PR DESCRIPTION
Including nesting, and with test coverage.
Also consolidated property value parsing code and added test for number properties.

This was blocking [US109321 [Android] Update Remaining Areas to use Folio Service APIs](https://rally1.rallydev.com/#/89963236876ud/detail/userstory/328382523156) because the "user" entity from the Folio API has a property ("image") whose value is an object. We don't (currently) need this property, but its presence caused this library to crash.