### PR TITLE
Support array and object property values

### DIFF
--- a/ksiren-gson-adapter/build.gradle
+++ b/ksiren-gson-adapter/build.gradle
@@ -2,7 +2,7 @@ def group = "com.brightspace.ksiren"
 def artifactName = "ksiren-gson-adapter"
 def vcsUrlSetting = "https://github.com/Brightspace/ksiren/"
 def description = 'Adapter to enable KSiren to parse Siren entities from JSON using Gson.'
-def versionValue = "1.1.0"
+def versionValue = "2.0.0"
 
 dependencies {
 	compile 'org.jetbrains.kotlin:kotlin-stdlib:1.3.31'

--- a/ksiren-gson-adapter/src/main/java/com/brightspace/ksiren/gson_adapter/KSirenGsonAdapter.kt
+++ b/ksiren-gson-adapter/src/main/java/com/brightspace/ksiren/gson_adapter/KSirenGsonAdapter.kt
@@ -48,8 +48,8 @@ class KSirenGsonAdapter(val gsonReader: JsonReader) : KSirenJsonReader() {
 		return gsonReader.nextString()
 	}
 
-	override fun nextBoolean(): String {
-		return gsonReader.nextBoolean().toString()
+	override fun nextBoolean(): Boolean {
+		return gsonReader.nextBoolean()
 	}
 
 	override fun nextNull() {

--- a/ksiren-moshi-adapter/build.gradle
+++ b/ksiren-moshi-adapter/build.gradle
@@ -2,7 +2,7 @@ def group = "com.brightspace.ksiren"
 def artifactName = "ksiren-moshi-adapter"
 def vcsUrlSetting = "https://github.com/Brightspace/ksiren/"
 def description = 'Adapter to enable KSiren to parse Siren entities from JSON using Moshi.'
-def versionValue = "1.1.0"
+def versionValue = "2.0.0"
 
 dependencies {
 	compile 'org.jetbrains.kotlin:kotlin-stdlib:1.3.31'

--- a/ksiren-moshi-adapter/src/main/java/com/brightspace/ksiren/moshi_adapter/KSirenMoshiAdapter.kt
+++ b/ksiren-moshi-adapter/src/main/java/com/brightspace/ksiren/moshi_adapter/KSirenMoshiAdapter.kt
@@ -52,8 +52,8 @@ class KSirenMoshiAdapter(val moshiReader: JsonReader) : KSirenJsonReader() {
 		}
 	}
 
-	override fun nextBoolean(): String {
-		return moshiReader.nextBoolean().toString()
+	override fun nextBoolean(): Boolean {
+		return moshiReader.nextBoolean()
 	}
 
 	override fun nextNull() {

--- a/ksiren/build.gradle
+++ b/ksiren/build.gradle
@@ -5,7 +5,7 @@ def group = "com.brightspace.ksiren"
 def artifactName = "ksiren"
 def vcsUrlSetting = "https://github.com/Brightspace/ksiren/"
 def description = 'Main package of KSiren: A Kotlin library for parsing responses from Siren API endpoints and building Siren Action requests.'
-def versionValue = "1.1.1"
+def versionValue = "2.0.0"
 
 dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib:1.3.31'

--- a/ksiren/src/main/java/com/brightspace/ksiren/Action.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Action.kt
@@ -15,7 +15,7 @@ package com.brightspace.ksiren
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-class Action(
+data class Action(
 	val name: String,
 	val classes: List<String> = listOf(),
 	val method: String = "GET",
@@ -95,7 +95,5 @@ class Action(
 		return false
 	}
 
-	override fun toJson(): CharSequence {
-		return JsonUtils.toJson(this)
-	}
+	override fun toJson() = JsonUtils.toJson(this)
 }

--- a/ksiren/src/main/java/com/brightspace/ksiren/ConditionalRead.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/ConditionalRead.kt
@@ -4,7 +4,7 @@ package com.brightspace.ksiren
  * Created by mpomeroy on 11/8/17.
  */
 fun conditionalRead(reader: KSirenJsonReader, setter:(String) -> Unit) {
-	val string = tryParseWithLambdasAsString(reader, { it.nextString() }, { it.nextBoolean() })
+	val string = tryParseWithLambdasAsString(reader, { it.nextString() }, { it.nextBoolean().toString() })
 	if (string != null) {
 		setter.invoke(string)
 	}

--- a/ksiren/src/main/java/com/brightspace/ksiren/Entity.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Entity.kt
@@ -18,6 +18,7 @@ package com.brightspace.ksiren
 class Entity(
 	val classes: List<String> = listOf(),
 	val properties: Map<String, String> = mapOf(),
+	val enhancedProperties: Map<String, PropertyValue> = mapOf(),
 	val entities: List<Entity> = listOf(),
 	val rel: List<String> = listOf(),
 	val actions: Map<String, Action> = mapOf(),
@@ -29,7 +30,7 @@ class Entity(
 
 		fun fromJson(reader: KSirenJsonReader): Entity {
 			val classes: MutableList<String> = mutableListOf()
-			val properties: MutableMap<String, String> = mutableMapOf()
+			val enhancedProperties: MutableMap<String, PropertyValue> = mutableMapOf()
 			val entities: MutableList<Entity> = mutableListOf()
 			val rel: MutableList<String> = mutableListOf()
 			val actions: MutableMap<String, Action> = mutableMapOf()
@@ -51,8 +52,8 @@ class Entity(
 						reader.beginObject()
 						while (reader.hasNext()) {
 							val propName = reader.nextName()
-							tryParsePropertyValue(reader)?.let { value ->
-								properties[propName] = value
+							parseEnhancedPropertyValue(reader)?.let { value ->
+								enhancedProperties[propName] = value
 							}
 						}
 						reader.endObject()
@@ -98,30 +99,59 @@ class Entity(
 				}
 			}
 			reader.endObject()
-			return Entity(classes, properties, entities, rel, actions, links, href, title)
+			val properties = enhancedProperties
+				.mapNotNull { entry ->
+					entry.value.let { propertyValue ->
+						when (propertyValue) {
+							is StringValue -> entry.key to propertyValue.stringValue
+							is BooleanValue -> entry.key to propertyValue.booleanValue.toString()
+							else -> null
+						}
+					}
+				}
+				.toMap()
+
+			return Entity(classes, properties, enhancedProperties, entities, rel, actions, links, href, title)
 		}
 
-		private fun ignoreArray(reader: KSirenJsonReader): String? {
+		private fun parseEnhancedPropertyValue(reader: KSirenJsonReader): PropertyValue? {
+			return tryParseWithLambdasAsPropertyValue(reader, ::parseString, ::parseBoolean, ::parseArray, ::parseObject)
+		}
+
+		private fun tryParseWithLambdasAsPropertyValue(reader: KSirenJsonReader, vararg parsingLambdas: (KSirenJsonReader) -> PropertyValue?): PropertyValue? {
+			for (parser in parsingLambdas) {
+				try {
+					return parser.invoke(reader)
+				} catch (e: Exception) {
+					//this mapper failed
+				}
+			}
+			throw KSirenException.ParseException("Could not parse PropertyValue")
+		}
+
+		private fun parseString(reader: KSirenJsonReader): StringValue? = reader.nextString()?.let { StringValue(it) }
+
+		private fun parseBoolean(reader: KSirenJsonReader) = BooleanValue.from(reader.nextBoolean())
+
+		private fun parseArray(reader: KSirenJsonReader): ArrayValue {
+			val elements = mutableListOf<PropertyValue>()
 			reader.beginArray()
 			while (reader.hasNext()) {
-				tryParsePropertyValue(reader)
+				parseEnhancedPropertyValue(reader)?.let { value -> elements.add(value) }
 			}
 			reader.endArray()
-			return null
+			return ArrayValue(elements)
 		}
 
-		private fun ignoreObject(reader: KSirenJsonReader): String? {
+		private fun parseObject(reader: KSirenJsonReader): ObjectValue {
+			val values = mutableMapOf<String, PropertyValue>()
 			reader.beginObject()
 			while (reader.hasNext()) {
-				reader.nextName()
-				tryParsePropertyValue(reader)
+				val name = reader.nextName()
+				parseEnhancedPropertyValue(reader)?.let { value -> values[name] = value }
 			}
 			reader.endObject()
-			return null
-		}
-
-		private fun tryParsePropertyValue(reader: KSirenJsonReader): String? {
-			return tryParseWithLambdasAsString(reader, { it.nextString() }, { it.nextBoolean() }, ::ignoreArray, ::ignoreObject)
+			return ObjectValue(values)
 		}
 	}
 

--- a/ksiren/src/main/java/com/brightspace/ksiren/Field.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Field.kt
@@ -48,7 +48,7 @@ class Field(
 					"value" -> {
 						value = tryParseWithLambdasAsString(reader,
 							{ it.nextString() },
-							{ it.nextBoolean() },
+							{ it.nextBoolean().toString() },
 							{ readAndReserializeArray(it) })
 
 					}

--- a/ksiren/src/main/java/com/brightspace/ksiren/Field.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Field.kt
@@ -15,11 +15,11 @@ package com.brightspace.ksiren
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-class Field(
+data class Field(
 	val name: String,
 	val classes: List<String> = listOf(),
 	val type: String = "text",
-	val value: String?) {
+	val value: String?) : JsonSerializable {
 
 	companion object {
 
@@ -67,7 +67,5 @@ class Field(
 		}
 	}
 
-	fun toJson(): CharSequence {
-		return JsonUtils.toJson(this)
-	}
+	override fun toJson() = JsonUtils.toJson(this)
 }

--- a/ksiren/src/main/java/com/brightspace/ksiren/KSirenJsonReader.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/KSirenJsonReader.kt
@@ -42,7 +42,7 @@ abstract class KSirenJsonReader {
 	}
 
 	abstract fun nextStringImpl(): String
-	abstract fun nextBoolean(): String
+	abstract fun nextBoolean(): Boolean
 	abstract protected fun nextNull()
 
 }

--- a/ksiren/src/main/java/com/brightspace/ksiren/Link.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Link.kt
@@ -15,7 +15,7 @@ package com.brightspace.ksiren
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-class Link(
+data class Link(
 	val rels: List<String>,
 	val classes: List<String> = listOf(),
 	val href: String,
@@ -85,7 +85,5 @@ class Link(
 		return classes.containsAll(clazz.toList())
 	}
 
-	override fun toJson(): CharSequence {
-		return JsonUtils.toJson(this)
-	}
+	override fun toJson() = JsonUtils.toJson(this)
 }

--- a/ksiren/src/main/java/com/brightspace/ksiren/PropertyValue.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/PropertyValue.kt
@@ -1,6 +1,8 @@
 package com.brightspace.ksiren
 
-sealed class PropertyValue
+sealed class PropertyValue : JsonSerializable {
+	override fun toJson() = JsonUtils.toJson(this)
+}
 
 data class StringValue(val stringValue: String) : PropertyValue()
 

--- a/ksiren/src/main/java/com/brightspace/ksiren/PropertyValue.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/PropertyValue.kt
@@ -1,0 +1,20 @@
+package com.brightspace.ksiren
+
+sealed class PropertyValue
+
+data class StringValue(val stringValue: String) : PropertyValue()
+
+// No point constructing instances when there are only two possibilities.
+// No need to be a data class since comparing by identity/reference is sufficient given only two instances.
+class BooleanValue private constructor(val booleanValue: Boolean) : PropertyValue() {
+	companion object {
+		val TRUE = BooleanValue(true)
+		val FALSE = BooleanValue(false)
+		fun from(b: Boolean) = if (b) TRUE else FALSE
+	}
+	override fun toString() = booleanValue.toString()
+}
+
+data class ArrayValue(val arrayElements: List<PropertyValue>) : PropertyValue()
+
+data class ObjectValue(val objectProperties: Map<String, PropertyValue>) : PropertyValue()

--- a/ksiren/src/test/java/com/brightspace/ksiren/ActionTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/ActionTest.kt
@@ -52,13 +52,4 @@ class ActionTest {
         assertTrue(action.hasField("productCode"))
         assertTrue(action.hasField("quantity"))
     }
-
-    @Test
-    fun serializeToJson() {
-        val json: String = """{ "name": "add-item", "title": "Add Item", "method": "POST", "href": "http://api.x.io/orders/42/items", "type": "application/x-www-form-urlencoded", "fields": [{ "name": "orderNumber", "type": "hidden", "value": "42" }, { "name": "productCode", "type": "text" }, { "name": "quantity", "type": "number" }] }"""
-        val action = Action.fromJson(json.toKSirenJsonReader())
-
-        // order of properties matters...
-        assertEquals(json, action.toJson())
-    }
 }

--- a/ksiren/src/test/java/com/brightspace/ksiren/EnhancedPropertyTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/EnhancedPropertyTest.kt
@@ -1,0 +1,124 @@
+package com.brightspace.ksiren
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class EnhancedPropertyTest {
+	@Test
+	fun testStringProperty() {
+		val stringName = "stringProperty"
+		val stringValue = "the value of a string property"
+		val json = """{"properties": { "$stringName": "$stringValue" } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.enhancedProperties,
+			expected = mapOf(stringName to StringValue(stringValue)))
+	}
+
+	@Test
+	fun testBooleanProperty() {
+		val trueName = "trueProperty"
+		val falseName = "falseProperty"
+		val json = """{"properties": { "$trueName": true, "$falseName": false } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.enhancedProperties,
+			expected = mapOf(trueName to BooleanValue.TRUE, falseName to BooleanValue.FALSE))
+	}
+
+	@Test
+	fun testArrayProperty() {
+		val arrayName = "arrayProperty"
+		val arrayElements = listOf("a", "b", "c").map(::StringValue)
+		val arrayElementsJson = arrayElements.joinToString { "\"${it.stringValue}\""}
+		val json = """{"properties": { "$arrayName": [$arrayElementsJson] } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.enhancedProperties,
+			expected = mapOf(arrayName to ArrayValue(arrayElements)))
+	}
+
+	@Test
+	fun testObjectProperty() {
+		val objectName = "objectProperty"
+		val objectProperties = mapOf("a" to "foo", "b" to "bar", "c" to "baz").mapValues { StringValue(it.value) }
+		val objectJson = objectProperties.entries.joinToString { "\"${it.key}\": \"${it.value.stringValue}\"" }
+		val json = """{"properties": { "$objectName": {$objectJson} } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.enhancedProperties,
+			expected = mapOf(objectName to ObjectValue(objectProperties)))
+	}
+
+	@Test fun testBooleanInArrayProperty() {
+		val arrayName = "arrayProperty"
+		val nestedArrayElements = listOf(true, false).map { BooleanValue.from(it) }
+		val nestedArrayElementsJson = nestedArrayElements.joinToString { it.booleanValue.toString() }
+		val json = """{"properties": { "$arrayName": [$nestedArrayElementsJson] } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.enhancedProperties,
+			expected = mapOf(arrayName to ArrayValue(nestedArrayElements)))
+	}
+
+	@Test
+	fun testArrayInArrayProperty() {
+		val arrayName = "arrayProperty"
+		val nestedArrayElements = listOf("a", "b", "c").map(::StringValue)
+		val nestedArrayElementsJson = nestedArrayElements.joinToString { "\"${it.stringValue}\""}
+		val json = """{"properties": { "$arrayName": [[$nestedArrayElementsJson]] } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.enhancedProperties,
+			expected = mapOf(arrayName to ArrayValue(listOf(ArrayValue(nestedArrayElements)))))
+	}
+
+	@Test
+	fun testObjectInArrayProperty() {
+		val arrayName = "arrayProperty"
+		val nestedObjectProperties = mapOf("a" to "foo", "b" to "bar", "c" to "baz").mapValues { StringValue(it.value) }
+		val nestedObjectJson = nestedObjectProperties.entries.joinToString { "\"${it.key}\": \"${it.value.stringValue}\"" }
+		val json = """{"properties": { "$arrayName": [{$nestedObjectJson}] } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.enhancedProperties,
+			expected = mapOf(arrayName to ArrayValue(listOf(ObjectValue(nestedObjectProperties)))))
+	}
+
+	@Test fun testBooleanInObjectProperty() {
+		val objectName = "objectProperty"
+		val nestedObjectProperties = mapOf("trueProperty" to BooleanValue.TRUE, "falseProperty" to BooleanValue.FALSE)
+		val nestedObjectJson = nestedObjectProperties.entries.joinToString { "\"${it.key}\": ${it.value.booleanValue}" }
+		val json = """{"properties": { "$objectName": {$nestedObjectJson} } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.enhancedProperties,
+			expected = mapOf(objectName to ObjectValue(nestedObjectProperties)))
+	}
+
+	@Test
+	fun testArrayInObjectProperty() {
+		val objectName = "objectProperty"
+		val nestedArrayName = "nestedArrayProperty"
+		val nestedArrayElements = listOf("a", "b", "c").map(::StringValue)
+		val nestedArrayElementsJson = nestedArrayElements.joinToString { "\"${it.stringValue}\""}
+		val json = """{"properties": { "$objectName": {"$nestedArrayName": [$nestedArrayElementsJson] } } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.enhancedProperties,
+			expected = mapOf(objectName to ObjectValue(mapOf(nestedArrayName to ArrayValue(nestedArrayElements)))))
+	}
+
+	@Test
+	fun testObjectInObjectProperty() {
+		val objectName = "objectProperty"
+		val nestedObjectName = "nestedObjectProperty"
+		val nestedObjectProperties = mapOf("a" to "foo", "b" to "bar", "c" to "baz").mapValues { StringValue(it.value) }
+		val nestedObjectJson = nestedObjectProperties.entries.joinToString { "\"${it.key}\": \"${it.value.stringValue}\"" }
+		val json = """{"properties": { "$objectName": {"$nestedObjectName": {$nestedObjectJson} } } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.enhancedProperties,
+			expected = mapOf(objectName to ObjectValue(mapOf(nestedObjectName to ObjectValue(nestedObjectProperties)))))
+	}
+}

--- a/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
@@ -89,15 +89,4 @@ class EntityTest {
 		assertTrue(entity.actions.isEmpty())
 		assertTrue(entity.links.isNotEmpty())
 	}
-
-    @Test
-    fun serializeToJson() {
-        // the parser cannot handle linked entities
-        // { "class": [ "items", "collection" ], "rel": [ "http://x.io/rels/order-items" ], "href": "http://api.x.io/orders/42/items"},
-        val json = """{ "class": [ "order" ], "properties": { "orderNumber": "42", "itemCount": "3", "status": "pending" }, "entities": [{ "class": [ "info", "customer" ], "rel": [ "http://x.io/rels/customer" ], "properties": { "customerId": "pj123", "name": "Peter Joseph" }, "links": [{ "rel": [ "self" ], "href": "http://api.x.io/customers/pj123" }] }], "actions": [{ "name": "add-item", "title": "Add Item", "method": "POST", "href": "http://api.x.io/orders/42/items", "type": "application/x-www-form-urlencoded", "fields": [{ "name": "orderNumber", "type": "hidden", "value": "42" }, { "name": "productCode", "type": "text" }, { "name": "quantity", "type": "number" }] }], "links": [{ "rel": [ "self" ], "href": "http://api.x.io/orders/42" }, { "rel": [ "previous" ], "href": "http://api.x.io/orders/41" }, { "rel": [ "next" ], "href": "http://api.x.io/orders/43" }] }"""
-        val entity = Entity.fromJson(json.toKSirenJsonReader())
-
-        // order of properties matters...
-        assertEquals(json, entity.toJson())
-    }
 }

--- a/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
@@ -70,6 +70,17 @@ class EntityTest {
 	}
 
 	@Test
+	fun expectHandleBooleanAsAsString() {
+		val truePropertyName = "trueProperty"
+		val falsePropertyName = "falseProperty"
+		val json = """{ "properties": { "$truePropertyName": true, "$falsePropertyName": false } }"""
+		val entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entity.properties,
+			expected = mapOf(truePropertyName to "true", falsePropertyName to "false"))
+	}
+
+	@Test
 	fun expectHandleNumber() {
 		val json = """{ "class": [ "order" ], "properties": { "orderNumber": 42, "status": "pending" }, "links": [{ "rel": [ "self" ], "href": "http://api.x.io/customers/pj123" }] }"""
 		val entity: Entity = Entity.fromJson(json.toKSirenJsonReader())

--- a/ksiren/src/test/java/com/brightspace/ksiren/FieldTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/FieldTest.kt
@@ -65,13 +65,4 @@ class FieldTest {
             assert(true)
         }
     }
-
-    @Test
-    fun serializeToJson() {
-        val json = """{ "name": "orderNumber", "type": "hidden", "value": "42" }"""
-        val field = Field.fromJson(json.toKSirenJsonReader())
-
-        // order of properties matters...
-        assertEquals(json, field.toJson())
-    }
 }

--- a/ksiren/src/test/java/com/brightspace/ksiren/LinkTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/LinkTest.kt
@@ -31,13 +31,4 @@ class LinkTest {
 		assertTrue(link.hasClass("link"))
 		assertFalse(link.hasClass("notLink"))
     }
-
-    @Test
-    fun serializeToJson() {
-        val json = """{ "rel": [ "self" ], "class": [ "link" ], "title": "my link", "type": "text/plain", "href": "http://api.x.io/orders/42" }"""
-        val link = Link.fromJson(json.toKSirenJsonReader())
-
-        // order of properties matters...
-        assertEquals(json, link.toJson())
-    }
 }

--- a/ksiren/src/test/java/com/brightspace/ksiren/ToJsonTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/ToJsonTest.kt
@@ -1,0 +1,114 @@
+package com.brightspace.ksiren
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class ToJsonTest {
+	@Test
+	fun testClassesToJson() {
+		val classes = listOf("class a", "class b")
+		val entity = Entity(classes = classes, href = null, title = null)
+		val json = entity.toJson().toString()
+		val entityFromJson = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entityFromJson.classes,
+			expected = classes)
+	}
+
+	@Test
+	fun testRelToJson() {
+		val rel = listOf("rel a", "rel b")
+		val entity = Entity(rel = rel, href = null, title = null)
+		val json = entity.toJson().toString()
+		val entityFromJson = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entityFromJson.rel,
+			expected = rel)
+	}
+
+	@Test
+	fun testPropertiesToJson() {
+		fun basicProperties(prefix: String = ""): Array<Pair<String, PropertyValue>> {
+			return arrayOf(
+				"${prefix}StringProperty" to StringValue("stringValue"),
+				"${prefix}TrueProperty" to BooleanValue.TRUE,
+				"${prefix}FalseProperty" to BooleanValue.FALSE)
+		}
+		fun basicValues() = basicProperties().map { it.second }
+		val properties = mapOf(
+			*basicProperties(),
+			"ObjectProperty" to ObjectValue(mapOf(
+				*basicProperties("Nested"),
+				"NestedObjectProperty" to ObjectValue(mapOf(*basicProperties("DoubleNested"))),
+				"NestedArrayProperty" to ArrayValue(basicValues()))),
+			"ArrayProperty" to ArrayValue(listOf(
+				*basicValues().toTypedArray(),
+				ObjectValue(mapOf(*basicProperties("Nested"))),
+				ArrayValue(basicValues()))))
+		val entity = Entity(enhancedProperties = properties, href = null, title = null)
+		val json = entity.toJson().toString()
+		val entityFromJson = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entityFromJson.enhancedProperties,
+			expected = properties)
+	}
+
+	@Test
+	fun testEntitiesToJson() {
+		val subEntities = listOf(
+			Entity(classes = listOf("sub-entity"), href = null, title = null)
+		)
+		val entity = Entity(entities = subEntities, href = null, title = null)
+		val json = entity.toJson().toString()
+		val entityFromJson = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entityFromJson.entities,
+			expected = subEntities)
+	}
+
+	@Test
+	fun testActionsToJson() {
+		// TODO: Array
+		val actions = (1..ContentType.values().size).map { a ->
+			"action name $a" to Action(
+				name = "action name $a",
+				classes = listOf("action class $a a", "action class $a b"),
+				method = "action method $a",
+				href = "action href $a",
+				title = "action title $a",
+				type = ContentType.values()[a - 1],
+				fields = (1..2).map { f ->
+					Field(
+						name = "field name $a-$f",
+						classes = listOf("field class $a-$f a", "field class $a-$f b"),
+						type = "field type $a-$f",
+						value = "field value $a-$f")
+				}
+			)
+		}.toMap()
+		val entity = Entity(actions = actions, href = null, title = null)
+		val json = entity.toJson().toString()
+		val entityFromJson = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entityFromJson.actions,
+			expected = actions)
+	}
+
+	@Test
+	fun testLinksToJson() {
+		val links = (1..2).map { i ->
+			Link(
+				rels = listOf("rel $i a", "rel $i b"),
+				classes = listOf("link class $i a", "link class $i b"),
+				href = "link href $i",
+				title = "link title $i",
+				type = "link type $i")
+		}
+		val entity = Entity(links = links, href = null, title = null)
+		val json = entity.toJson().toString()
+		val entityFromJson = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals(
+			actual = entityFromJson.links,
+			expected = links)
+	}
+}


### PR DESCRIPTION
Added Entity.enhancedProperties to support array and object property values
- Also models Booleans explicitly rather than as strings.
- Added tests.

Fixed serialization:
- Simplified serialization implementation:
  - include array, objects properties via enhancedProperties
  - use joinToString to avoid misplaced commas
- New suite of tests for serialization (removed old ones)