### PR TITLE
US125152 Ignore additional values

### DIFF
--- a/ksiren-gson-adapter/src/main/java/com/brightspace/ksiren/gson_adapter/KSirenGsonReader.kt
+++ b/ksiren-gson-adapter/src/main/java/com/brightspace/ksiren/gson_adapter/KSirenGsonReader.kt
@@ -52,6 +52,10 @@ class KSirenGsonReader(private val gsonReader: JsonReader) : KSirenJsonReader() 
 		return gsonReader.nextBoolean()
 	}
 
+	override fun skipValue() {
+		return gsonReader.skipValue()
+	}
+
 	override fun nextNull() {
 		gsonReader.nextNull()
 	}

--- a/ksiren-moshi-adapter/src/main/java/com/brightspace/ksiren/moshi_adapter/KSirenMoshiReader.kt
+++ b/ksiren-moshi-adapter/src/main/java/com/brightspace/ksiren/moshi_adapter/KSirenMoshiReader.kt
@@ -44,6 +44,10 @@ class KSirenMoshiReader(val moshiReader: JsonReader) : KSirenJsonReader() {
 		return moshiReader.nextName()
 	}
 
+	override fun skipValue() {
+		return moshiReader.skipValue()
+	}
+
 	override fun nextStringImpl(): String {
 		try {
 			return moshiReader.nextString()

--- a/ksiren/src/main/java/com/brightspace/ksiren/Action.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Action.kt
@@ -68,6 +68,9 @@ data class Action(
 						}
 						reader.endArray()
 					}
+					else -> {
+						reader.skipValue()
+					}
 				}
 			}
 			reader.endObject()

--- a/ksiren/src/main/java/com/brightspace/ksiren/Entity.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Entity.kt
@@ -110,6 +110,9 @@ data class Entity internal constructor(
 					"href" -> {
 						href = reader.nextString()
 					}
+					else -> {
+						reader.skipValue()
+					}
 				}
 			}
 			reader.endObject()

--- a/ksiren/src/main/java/com/brightspace/ksiren/Field.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Field.kt
@@ -50,7 +50,9 @@ data class Field(
 							{ it.nextString() },
 							{ it.nextBoolean().toString() },
 							{ readAndReserializeArray(it) })
-
+					}
+					else -> {
+						reader.skipValue()
 					}
 				}
 			}

--- a/ksiren/src/main/java/com/brightspace/ksiren/KSirenJsonReader.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/KSirenJsonReader.kt
@@ -44,6 +44,7 @@ abstract class KSirenJsonReader {
 
 	abstract fun nextStringImpl(): String
 	abstract fun nextBoolean(): Boolean
+	abstract fun skipValue()
 	abstract protected fun nextNull()
 
 }

--- a/ksiren/src/main/java/com/brightspace/ksiren/Link.kt
+++ b/ksiren/src/main/java/com/brightspace/ksiren/Link.kt
@@ -57,7 +57,9 @@ data class Link(
 					"type" -> {
 						type = reader.nextString()
 					}
-
+					else -> {
+						reader.skipValue()
+					}
 				}
 			}
 			reader.endObject()

--- a/ksiren/src/test/java/com/brightspace/ksiren/ActionTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/ActionTest.kt
@@ -74,6 +74,14 @@ class ActionTest {
 	}
 
 	@Test
+	fun ignoreAdditionalPropertiesTest() {
+		val json = """{ "name": "add-item", "href": "http://api.x.io/orders/42/items", "min": 5.0, "max": 60, "extra": "stuff", "bar": true }"""
+		val action: Action = Action.fromJson(json.toKSirenJsonReader())
+		assertEquals("add-item", action.name)
+		assertEquals("http://api.x.io/orders/42/items", action.href)
+	}
+
+	@Test
 	fun expectEscapedFieldString() {
 		val action = createJsonAction(listOf(Field("escapedString", listOf(), "text", stringRequiringJsonEscape)))
 		val actionJson = action.toJson(KSirenMoshiWriter())

--- a/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/EntityTest.kt
@@ -70,6 +70,13 @@ class EntityTest {
 	}
 
 	@Test
+	fun ignoreAdditionalPropertiesTest() {
+		val json = """{ "title": "entity-title", "min": 5.0, "max": 60, "extra": "stuff", "bar": true }"""
+		val entity: Entity = Entity.fromJson(json.toKSirenJsonReader())
+		assertEquals("entity-title", entity.title)
+	}
+
+	@Test
 	fun expectHandleBooleanAsAsString() {
 		val truePropertyName = "trueProperty"
 		val falsePropertyName = "falseProperty"

--- a/ksiren/src/test/java/com/brightspace/ksiren/FieldTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/FieldTest.kt
@@ -58,6 +58,14 @@ class FieldTest {
 	}
 
 	@Test
+	fun ignoreAdditionalPropertyTest() {
+		val field: Field = Field.fromJson("""{ "name": "expressShipping", "min": 5.0, "max": 60, "extra": "stuff", "bar": true }""".toKSirenJsonReader())
+		assertEquals("expressShipping", field.name)
+		assertEquals("text", field.type)
+		assertEquals(null, field.value)
+	}
+
+	@Test
 	fun expectJsonException() {
 		try {
 			Field.fromJson("""{ "name": "orderNumber" "type": "hidden", "value": "42" }""".toKSirenJsonReader())

--- a/ksiren/src/test/java/com/brightspace/ksiren/LinkTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/LinkTest.kt
@@ -31,4 +31,12 @@ class LinkTest {
 		assertTrue(link.hasClass("link"))
 		assertFalse(link.hasClass("notLink"))
 	}
+
+	@Test
+	fun ignoreAdditionalPropertiesTest() {
+		val json = """{ "rel": [ "self" ], "href": "http://api.x.io/orders/42", "min": 5.0, "max": 60, "extra": "stuff", "bar": true }"""
+		val link: Link = Link.fromJson(json.toKSirenJsonReader())
+		assertEquals(listOf("self"), link.rels)
+		assertEquals("http://api.x.io/orders/42", link.href)
+	}
 }


### PR DESCRIPTION
Came up while attempting to parse a Siren response that has extra values, in particular a min/max on a Field. Siren doesn't really make a decision about extra values one way or the other, so at the very least we shouldn't be exploding when they are present. (Ideally, the values would get passed through, but that's difficult in strongly-typed languages.)

This adds a case to simply skip a token if it doesn't match our expected set of token names. This does mean an Entity/Link/Action/Field parsed with KSiren will _not_ fully represent the original JSON string, but this is a slight improvement over just breaking.

Note that this does mean `fromJson` is now lossy, but only in cases where we previously would have just thrown an exception anyway.