### PR TITLE
Ignore null action field values + remove Bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [ ![Kotlin](https://img.shields.io/badge/Kotlin-1.3.31-blue.svg)](http://kotlinlang.org)
 ![Build status](https://travis-ci.com/Brightspace/ksiren.svg?token=bx5yfkuXAPjvTyLvsLn4&branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/Brightspace/ksiren/badge.svg?branch=master)](https://coveralls.io/github/Brightspace/ksiren?branch=master)
-[![Download](https://api.bintray.com/packages/brightspace/ksiren/ksiren/images/download.svg) ](https://bintray.com/brightspace/ksiren/ksiren/_latestVersion)
 
 A Kotlin library for parsing responses from Siren API endpoints and building Siren Action requests.
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 		classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2"
 		classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.9.18"
-		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 	}
 }
 
@@ -25,7 +24,6 @@ subprojects {
 	apply plugin: 'kotlin'
 	apply plugin: 'maven'
 	apply plugin: 'org.jetbrains.dokka'
-	apply plugin: 'com.jfrog.bintray'
 	apply plugin: 'maven-publish'
 
 	task sourcesJar(type: Jar) {

--- a/ksiren-gson-adapter/build.gradle
+++ b/ksiren-gson-adapter/build.gradle
@@ -11,25 +11,6 @@ dependencies {
 	compileOnly project(":ksiren")
 }
 
-bintray {
-	user = System.getenv('BINTRAY_USER')
-	key = System.getenv('BINTRAY_KEY')
-	publications = ['MyPublication']
-	pkg {
-		repo = 'ksiren'
-		name = artifactName
-		userOrg = 'brightspace'
-		licenses = ['Apache-2.0']
-		vcsUrl = vcsUrlSetting
-		version {
-			name = versionValue
-			desc = description
-			released = new Date()
-			vcsTag = versionValue
-		}
-	}
-}
-
 // Create the pom configuration:
 def pomConfig = {
 	licenses {

--- a/ksiren-moshi-adapter/build.gradle
+++ b/ksiren-moshi-adapter/build.gradle
@@ -12,25 +12,6 @@ dependencies {
 	compileOnly project(":ksiren")
 }
 
-bintray {
-	user = System.getenv('BINTRAY_USER')
-	key = System.getenv('BINTRAY_KEY')
-	publications = ['MyPublication']
-	pkg {
-		repo = 'ksiren'
-		name = artifactName
-		userOrg = 'brightspace'
-		licenses = ['Apache-2.0']
-		vcsUrl = vcsUrlSetting
-		version {
-			name = versionValue
-			desc = description
-			released = new Date()
-			vcsTag = versionValue
-		}
-	}
-}
-
 // Create the pom configuration:
 def pomConfig = {
 	licenses {

--- a/ksiren-okhttp3-plugin/build.gradle
+++ b/ksiren-okhttp3-plugin/build.gradle
@@ -11,25 +11,6 @@ dependencies {
 	compileOnly project(":ksiren")
 }
 
-bintray {
-	user = System.getenv('BINTRAY_USER')
-	key = System.getenv('BINTRAY_KEY')
-	publications = ['MyPublication']
-	pkg {
-		repo = 'ksiren'
-		name = artifactName
-		userOrg = 'brightspace'
-		licenses = ['Apache-2.0']
-		vcsUrl = vcsUrlSetting
-		version {
-			name = versionValue
-			desc = description
-			released = new Date()
-			vcsTag = versionValue
-		}
-	}
-}
-
 // Create the pom configuration:
 def pomConfig = {
 	licenses {

--- a/ksiren-okhttp3-plugin/src/main/java/com/brightspace/ksiren/okhttp3_plugin/KSirenOkhttp3RequestBuilder.kt
+++ b/ksiren-okhttp3-plugin/src/main/java/com/brightspace/ksiren/okhttp3_plugin/KSirenOkhttp3RequestBuilder.kt
@@ -31,7 +31,9 @@ class KSirenOkhttp3RequestBuilder(wrappedAction: Action, private val writer: KSi
 			when (action.method) {
 				"GET" -> {
 					action.fields.forEach {
-						urlBuilder.addQueryParameter(it.name, it.value)
+						if (it.value != null ) {
+							urlBuilder.addQueryParameter(it.name, it.value)
+						}
 					}
 					requestBuilder.get()
 				}

--- a/ksiren/build.gradle
+++ b/ksiren/build.gradle
@@ -36,25 +36,6 @@ coveralls {
 	jacocoReportPath = "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
 }
 
-bintray {
-	user = System.getenv('BINTRAY_USER')
-	key = System.getenv('BINTRAY_KEY')
-	publications = ['MyPublication']
-	pkg {
-		repo = artifactName
-		name = artifactName
-		userOrg = 'brightspace'
-		licenses = ['Apache-2.0']
-		vcsUrl = vcsUrlSetting
-		version {
-			name = versionValue
-			desc = description
-			released = new Date()
-			vcsTag = versionValue
-		}
-	}
-}
-
 // Create the pom configuration:
 def pomConfig = {
 	licenses {

--- a/ksiren/src/test/java/com/brightspace/ksiren/ActionTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/ActionTest.kt
@@ -60,7 +60,6 @@ class ActionTest {
 		assertEquals("GET", action.method)
 		assertEquals("http://api.x.io/orders/42/items", action.href)
 		assertEquals("Test this thing", action.title)
-		assertEquals("Test this thing", action.title)
 	}
 
 	@Test

--- a/ksiren/src/test/java/com/brightspace/ksiren/KSirenRequestBuilderTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/KSirenRequestBuilderTest.kt
@@ -4,7 +4,6 @@ import com.brightspace.ksiren.moshi_adapter.KSirenMoshiWriter
 import com.brightspace.ksiren.okhttp3_request_builder.KSirenOkhttp3RequestBuilder
 import okhttp3.MultipartBody
 import okhttp3.Request
-import okio.BufferedSink
 import okio.Okio
 import org.junit.Test
 import org.junit.jupiter.api.DynamicTest
@@ -86,7 +85,7 @@ class KSirenRequestBuilderTest {
 						val contentSink = Okio.buffer(outputSink)
 
 						assertEquals(1, body.parts().size)
-						assertEquals("Content-Disposition: form-data; name=\"testParam\"\n", body.part(0).headers().toString())
+						assertEquals("form-data; name=\"testParam\"", body.part(0).headers()?.get("Content-Disposition"))
 
 						body.part(0).body().writeTo(contentSink)
 						contentSink.flush()

--- a/ksiren/src/test/java/com/brightspace/ksiren/KSirenRequestBuilderTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/KSirenRequestBuilderTest.kt
@@ -7,13 +7,10 @@ import okhttp3.Request
 import okio.BufferedSink
 import okio.Okio
 import org.junit.Test
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 import java.io.ByteArrayOutputStream
-import java.io.OutputStream
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertTrue
 import kotlin.test.fail
 

--- a/ksiren/src/test/java/com/brightspace/ksiren/KSirenRequestBuilderTest.kt
+++ b/ksiren/src/test/java/com/brightspace/ksiren/KSirenRequestBuilderTest.kt
@@ -2,12 +2,20 @@ package com.brightspace.ksiren
 
 import com.brightspace.ksiren.moshi_adapter.KSirenMoshiWriter
 import com.brightspace.ksiren.okhttp3_request_builder.KSirenOkhttp3RequestBuilder
+import okhttp3.MultipartBody
 import okhttp3.Request
+import okio.BufferedSink
+import okio.Okio
 import org.junit.Test
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
+import kotlin.test.fail
 
 /**
  * Copyright 2017 D2L Corporation
@@ -34,7 +42,11 @@ class KSirenRequestBuilderTest {
 			href = "http://www.example.com",
 			title = "title",
 			type = contentType,
-			fields = listOf(Field("testParam", listOf(), "text", null)))
+			fields = listOf(
+				Field("testParam", listOf(), "text", null),
+				Field("unpopulatedParam", listOf(), "text", null)
+			)
+		)
 	}
 
 	@Test
@@ -58,12 +70,37 @@ class KSirenRequestBuilderTest {
 				KSirenMoshiWriter()
 			)
 			requestBuilder.addFieldValue("testParam", "testValue")
-			requestBuilder.build()
 
-			//As far as I know there isn't a good way to verify the requestbody
-			//however, doing so would only be testing Okhttp3 anyway. Ensuring
-			//this doesn't throw an exception should be good enough.
-			Assertions.assertTrue(true)
+			val res = requestBuilder.build()
+
+			when (contentType) {
+				ContentType.JSON -> {
+					assertEquals("http://www.example.com/?testParam=testValue", res.url().toString())
+				}
+				ContentType.FORM -> {
+					assertEquals("http://www.example.com/", res.url().toString())
+					assertTrue(res.body() is MultipartBody)
+
+					if (res.body() is MultipartBody) {
+						val body = res.body() as MultipartBody
+
+						val outputStream = ByteArrayOutputStream()
+						val outputSink = Okio.sink(outputStream)
+						val contentSink = Okio.buffer(outputSink)
+
+						assertEquals(1, body.parts().size)
+						assertEquals("Content-Disposition: form-data; name=\"testParam\"\n", body.part(0).headers().toString())
+
+						body.part(0).body().writeTo(contentSink)
+						contentSink.flush()
+
+						assertEquals("testValue", outputStream.toString())
+					}
+				}
+				else -> {
+					fail("Unknown Content-Type: ${contentType}")
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Upstream consumers assume they may receive actions with null field values, and test that it isn't serialized on the response.